### PR TITLE
Fix relative url resolving issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ function _pathResolve (path) {
   if (pathSplit[0] === '') {
     pathSplit = pathSplit.slice(1);
   }
+
   // let segmentCount = 0; // number of segments that have been passed
   let resultArray = [];
   pathSplit.forEach((current, index) => {
@@ -171,23 +172,35 @@ function urlResolve (base, relative) {
     if (_shouldAddSlash(relativeObj.href)) {
       return _addSlash(relativeObj.href);
     }
+
     return relativeObj.href;
   } else if (relativeObj.absolutePath) { // relative is an absolute path
     const {path, query, hash} = relativeObj;
+
     return baseObj.host + _pathResolve(path) + query + hash;
   } else if (relativeObj.relativePath) { // relative is a relative path
     const {path, query, hash} = relativeObj;
+
     let basePath = baseObj.path;
-    // remove last segment if no slash at end
-    basePath = basePath.substring(0, basePath.lastIndexOf('/'));
     let resultString = baseObj.host;
-    const resolvePath = _pathResolve(basePath + '/' + path);
+
+    let resolvePath;
+
+    if (path.length === 0) {
+      resolvePath = basePath;
+    } else {
+      // remove last segment if no slash at end
+      basePath = basePath.substring(0, basePath.lastIndexOf('/'));
+      resolvePath = _pathResolve(basePath + '/' + path);
+    }
+
     // if result is just the base host, add /
     if ((resolvePath === '') && (!query) && (!hash)) {
       resultString += '/';
     } else {
       resultString += resolvePath + query + hash;
     }
+
     return resultString;
   }
 }

--- a/index.js
+++ b/index.js
@@ -22,11 +22,13 @@ function _pathResolve (path) {
   // let segmentCount = 0; // number of segments that have been passed
   let resultArray = [];
   pathSplit.forEach((current, index) => {
-    let rli = resultArray.length - 1; // resultArray last index
-    if (current === '..') {
-      resultArray = resultArray.slice(rli-1, rli); // remove previous
-    } else if (current !== '') {
-      resultArray.push(current);
+    // skip occurances of '.'
+    if (current !== '.') {
+      if (current === '..') {
+        resultArray.pop(); // remove previous
+      } else if (current !== '') {
+        resultArray.push(current);
+      }
     }
   });
   return '/' + resultArray.join('/');

--- a/test/TestCase.js
+++ b/test/TestCase.js
@@ -8,19 +8,9 @@ module.exports = class TestCase {
    this.base = base;
    this.relative = relative;
    this.expectedResult = expectedResult;
-   this.actualResult = null;
  }
- result () {
-   this.actualResult = resolveUrl(this.base, this.relative);
-   if (this.expectedResult !== this.actualResult) {
-     console.log('\nTestCase failure: ');
-     console.log('Base: ', this.base);
-     console.log('Relative: ', this.relative);
-     console.log('Expected Result: ', this.expectedResult);
-     console.log('Actual Result: ', this.actualResult);
-     console.log();
-     return false;
-   }
-   return true;
+
+ getActualResult () {
+   return resolveUrl(this.base, this.relative);
  }
 };

--- a/test/test.js
+++ b/test/test.js
@@ -11,6 +11,74 @@ const chai = require('chai');
 const expect = chai.expect;
 
 describe('url resolve test', function () {
+  const tests = [
+    new TestCase(
+      '',
+      'about:robots',
+      'about:robots'
+    ),
+    new TestCase(
+      '',
+      'http://test.com',
+      'http://test.com/'
+    ),
+    new TestCase(
+      'http://test.com/path?query#hash',
+      '',
+      'http://test.com/path?query'
+    ),
+    new TestCase(
+      'http://test.com',
+      'http://relative.com',
+      'http://relative.com/'
+    ),
+    new TestCase(
+      'http://test.com/with/a/path',
+      '/absolute/path',
+      'http://test.com/absolute/path'
+    ),
+    new TestCase(
+      'http://test.com/example/path/index.html',
+      'relative/path',
+      'http://test.com/example/path/relative/path'
+    ),
+    new TestCase(
+      'http://test.com/path/',
+      'other/path',
+      'http://test.com/path/other/path'
+    ),
+    new TestCase(
+      '  http://test.com?query#hash    ',
+      '   path?query#hash',
+      'http://test.com/path?query#hash'
+    ),
+    new TestCase(
+      'http://nah.com',
+      'http://test.com/path/file.html',
+      'http://test.com/path/file.html'
+    ),
+    new TestCase(
+      'https://agileui.com/demo/monarch/demo/admin-template/index.html',
+      './assets/images/icons/apple-touch-icon-114-precomposed.png',
+      'https://agileui.com/demo/monarch/demo/admin-template/assets/images/icons/apple-touch-icon-114-precomposed.png'
+    ),
+    new TestCase(
+      'https://agileui.com/demo/monarch/demo/admin-template/index.html',
+      '../assets/images/icons/apple-touch-icon-114-precomposed.png',
+      'https://agileui.com/demo/monarch/demo/assets/images/icons/apple-touch-icon-114-precomposed.png'
+    ),
+    new TestCase(
+      'https://agileui.com/demo/monarch/demo/admin-template/index.html',
+      '../../assets/images/icons/apple-touch-icon-114-precomposed.png',
+      'https://agileui.com/demo/monarch/assets/images/icons/apple-touch-icon-114-precomposed.png'
+    ),
+    new TestCase(
+      'https://agileui.com/demo/monarch/demo/admin-template/index.html',
+      '../../assets/images/../images/icons/apple-touch-icon-114-precomposed.png',
+      'https://agileui.com/demo/monarch/assets/images/icons/apple-touch-icon-114-precomposed.png'
+    )
+  ];
+
   it('should have the same outputs as node.js\' url.resolve.', function () {
     const hrefs = [
       'http://example.com/',
@@ -39,56 +107,14 @@ describe('url resolve test', function () {
     expect(thisUrlResolve.bind(undefined, 'http:/nope.com', '')).to.throw(Error);
   });
 
-  it('should have expected outcomes', function () {
-    const tests = [
-      new TestCase(
-        '',
-        'about:robots',
-        'about:robots'
-      ),
-      new TestCase(
-        '',
-        'http://test.com',
-        'http://test.com/'
-      ),
-      new TestCase(
-        'http://test.com/path?query#hash',
-        '',
-        'http://test.com/path?query'
-      ),
-      new TestCase(
-        'http://test.com',
-        'http://relative.com',
-        'http://relative.com/'
-      ),
-      new TestCase(
-        'http://test.com/with/a/path',
-        '/absolute/path',
-        'http://test.com/absolute/path'
-      ),
-      new TestCase(
-        'http://test.com/example/path/index.html',
-        'relative/path',
-        'http://test.com/example/path/relative/path'
-      ),
-      new TestCase(
-        'http://test.com/path/',
-        'other/path',
-        'http://test.com/path/other/path'
-      ),
-      new TestCase(
-        '  http://test.com?query#hash    ',
-        '   path?query#hash',
-        'http://test.com/path?query#hash'
-      ),
-      new TestCase(
-        'http://nah.com',
-        'http://test.com/path/file.html',
-        'http://test.com/path/file.html'
-      )
-    ];
-    tests.forEach((testCase) => {
-      expect(testCase.result()).to.be.true;
+  tests.forEach((testCase) => {
+    let {base, relative, expectedResult, actualResult} = testCase;
+    let testDescription = `should resolve base url: ${base}\n` +
+      `    with relative url: ${relative}\n` +
+      `    to ${expectedResult}`;
+
+    it(testDescription, () => {
+      expect(testCase.getActualResult()).to.equal(expectedResult);
     });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -76,6 +76,16 @@ describe('url resolve test', function () {
       'https://agileui.com/demo/monarch/demo/admin-template/index.html',
       '../../assets/images/../images/icons/apple-touch-icon-114-precomposed.png',
       'https://agileui.com/demo/monarch/assets/images/icons/apple-touch-icon-114-precomposed.png'
+    ),
+    new TestCase(
+      'https://agileui.com/demo/monarch/demo/admin-angular/index.html#/',
+      '#test',
+      'https://agileui.com/demo/monarch/demo/admin-angular/index.html#test'
+    ),
+    new TestCase(
+      'https://agileui.com/demo/monarch/demo/admin-angular/index.html#/',
+      '../../assets/image-resources/gravatar.jpg',
+      'https://agileui.com/demo/monarch/assets/image-resources/gravatar.jpg'
     )
   ];
 


### PR DESCRIPTION
Relative paths were not getting resolved correctly.

For example:
base path: `https://agileui.com/demo/monarch/demo/admin-template/index.html`
with relative path: `../assets/images/icons/apple-touch-icon-114-precomposed.png`
expected result: `https://agileui.com/demo/monarch/demo/assets/images/icons/apple-touch-icon-114-precomposed.png`

actual result: `https://agileui.com/demo/assets/images/icons/apple-touch-icon-114-precomposed.png`

This PR fixes that issue and also adds support for paths that contain a `.`.
