### PR TITLE
Fix resolving URL with double slash in hash

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,11 @@ function _baseParse (base) {
 
   return resultObject;
 }
+
+// https://tools.ietf.org/html/rfc3986#section-3.1
+const _scheme = '[a-z][a-z0-9+.-]*'; // ALPHA *( ALPHA / DIGIT / "+" / "-" / "."  )]
+const _isAbsolute = new RegExp(`^(${_scheme}:)?//`, 'i');
+
 // parses a relative url string into an object containing the href,
 // hash, query and whether it is a net path, absolute path or relative path
 function _relativeParse (relative) {
@@ -93,8 +98,7 @@ function _relativeParse (relative) {
   };
   // check for protocol
   // if protocol exists, is net path (absolute URL)
-  const protocolIndex = relative.indexOf('//');
-  if (protocolIndex !== -1) {
+  if (_isAbsolute.test(relative)) {
     resultObject.netPath = true;
     // return, in this case the relative is the resolved url, no need to parse.
     return resultObject;

--- a/test/test.js
+++ b/test/test.js
@@ -91,6 +91,31 @@ describe('url resolve test', function () {
       'https://twitch.tv',
       '//web-cdn.twnv.net/assets/application.css',
       'https://web-cdn.twnv.net/assets/application.css'
+    ),
+    new TestCase(
+      'http://example.com/aaa#/foo/',
+      '#/foo//bar',
+      'http://example.com/aaa#/foo//bar'
+    ),
+    new TestCase(
+      'http://example.com/aaa',
+      '?url=/foo//bar',
+      'http://example.com/aaa?url=/foo//bar'
+    ),
+    new TestCase(
+      'http://example.com/aaa',
+      '/a//b',
+      'http://example.com/a/b'
+    ),
+    new TestCase(
+      'http://example.com/aaa/bbb',
+      'a//b',
+      'http://example.com/aaa/a/b'
+    ),
+    new TestCase(
+      'http://example.com/aaa',
+      '?url=http://foo.com/bar',
+      'http://example.com/aaa?url=http://foo.com/bar'
     )
   ];
 
@@ -123,7 +148,7 @@ describe('url resolve test', function () {
   });
 
   tests.forEach((testCase) => {
-    let {base, relative, expectedResult, actualResult} = testCase;
+    let {base, relative, expectedResult} = testCase;
     let testDescription = `should resolve base url: ${base}\n` +
       `    with relative url: ${relative}\n` +
       `    to ${expectedResult}`;


### PR DESCRIPTION
I came across a bug that was causing me problems. Thanks for taking a look.

There was a rule that treated any relative URL with `//` as an absolute URL. This tightens that rule to only match if the URL starts with a valid scheme followed by `://`, or just starts with `//`.

I approximate scheme detection by looking for characters that are allowed in a scheme (https://tools.ietf.org/html/rfc3986#section-3.1) followed immediately by `://`.