### PR TITLE
Don't drop slash at the end of paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function _pathResolve (path) {
     if (current !== '.') {
       if (current === '..') {
         resultArray.pop(); // remove previous
-      } else if (current !== '') {
+      } else if (current !== '' || index === pathSplit.length - 1) {
         resultArray.push(current);
       }
     }

--- a/test/test.js
+++ b/test/test.js
@@ -38,6 +38,11 @@ describe('url resolve test', function () {
       'http://test.com/absolute/path'
     ),
     new TestCase(
+      'http://test.com/path/with/a',
+      '/trailing/slash/',
+      'http://test.com/trailing/slash/'
+    ),
+    new TestCase(
       'http://test.com/example/path/index.html',
       'relative/path',
       'http://test.com/example/path/relative/path'


### PR DESCRIPTION
I noticed that trailing slashes are getting dropped when resolving URLs. This appears to be an bug with the code that drops extra slashes between path segments. I added an additional condition to make sure the slash isn't at the end before dropping it.