### PR TITLE
Fix for throwing errors when a protocol can't be resolved

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,10 +47,6 @@ function _baseParse (base) {
   let path = base;
   let protocolEndIndex = base.indexOf('//');
 
-  if (protocolEndIndex === -1) {
-    throw new Error('Error, protocol is not specified');
-  }
-
   resultObject.protocol = path.substring(0, protocolEndIndex);
 
   protocolEndIndex += 2; // add two to pass double slash
@@ -109,7 +105,7 @@ function _relativeParse (relative) {
   if (relative[0] === '/') {
     resultObject.absolutePath = true;
     // return resultObject
-  } else {
+  } else if (relative !== '') {
     resultObject.relativePath = true;
   }
 
@@ -159,26 +155,12 @@ function urlResolve (base, relative) {
     return relative;
   }
 
-  // if base is empty, assume relative is a net path.
-  if (base === '') {
-    if (_shouldAddSlash(relative)) {
-      return _addSlash(relative);
-    }
-    // add / at end if not present if is only the host
-    return relative;
-  }
   const baseObj = _baseParse(base);
-  // relative is empty, return base minus hash
-  if (relative === '') {
-    const {host, path, query} = baseObj;
-    // when path and query aren't supplied add slash
-    if ((!path) && (!query)) {
-      return _addSlash(host);
-    }
-    return host + path + query;
-  }
-
   const relativeObj = _relativeParse(relative);
+
+  if (!baseObj.protocol && !relativeObj.netPath) {
+    throw new Error('Error, protocol is not specified');
+  }
 
   if (relativeObj.netPath) { // relative is full qualified URL
     if (_shouldAddProtocol(relativeObj.href)) {
@@ -218,5 +200,12 @@ function urlResolve (base, relative) {
     }
 
     return resultString;
+  } else {
+    const {host, path, query} = baseObj;
+    // when path and query aren't supplied add slash
+    if ((!path) && (!query)) {
+      return _addSlash(host);
+    }
+    return host + path + query + relativeObj.hash;
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -23,6 +23,11 @@ describe('url resolve test', function () {
       'http://test.com/'
     ),
     new TestCase(
+      '#yolo',
+      'http://test.com',
+      'http://test.com/'
+    ),
+    new TestCase(
       'http://test.com/path?query#hash',
       '',
       'http://test.com/path?query'
@@ -143,7 +148,7 @@ describe('url resolve test', function () {
   });
 
   it('should throw error if the first argument is not a net path', function () {
-    expect(thisUrlResolve.bind(undefined,'#yolo', '/foo/bar')).to.throw(Error);
+    expect(thisUrlResolve.bind(undefined, '#yolo', '/foo/bar')).to.throw(Error);
     expect(thisUrlResolve.bind(undefined, 'http:/nope.com', '')).to.throw(Error);
   });
 


### PR DESCRIPTION
I ran into an issue where the "protocol is not specified" error is getting thrown when it shouldn't. Given a base that is just a URL fragment (hash), it should behave the same as a base that is empty.

```javascript
const result = resolveUrl("#foo", "http://example.com/f");
// Expected result: http://example.com/f
// Current result: Error("Error, protocol is not specified")
```

I had to refactor a bit to get it to work, but I think it came out well.